### PR TITLE
Adds in a loader for a statics URL

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ twine==1.7.4
 Django==1.10.1
 django-jinja==2.2.1
 django-jinja2==0.1
+requests==2.21.0
 unittest2==1.1.0

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -118,6 +118,11 @@ WEBPACK_LOADER = {
         'CACHE': False,
         'BUNDLE_DIR_NAME': 'bundles/',
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats-app2.json'),
+    },
+    'APP3': {
+        'CACHE': False,
+        'BUNDLE_DIR_NAME': 'bundles/',
+        'STATS_URL': "http://example.testing.url.internal/webpack-stats.json",
     }
 }
 

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -5,6 +5,8 @@ from subprocess import call
 from threading import Thread
 
 import django
+import requests
+
 from django.conf import settings
 from django.test import RequestFactory, TestCase
 from django.views.generic.base import TemplateView
@@ -21,6 +23,7 @@ from webpack_loader.utils import get_loader
 
 BUNDLE_PATH = os.path.join(settings.BASE_DIR, 'assets/bundles/')
 DEFAULT_CONFIG = 'DEFAULT'
+APP3 = 'APP3'
 
 
 class LoaderTestCase(TestCase):
@@ -189,6 +192,18 @@ class LoaderTestCase(TestCase):
             ).format(stats_file)
             self.assertIn(expected, str(e))
 
+    def test_bad_stats_url(self):
+        stats_url = "http://example.testing.url.internal/webpack-stats.json"
+        try:
+            get_loader(APP3).get_assets()
+        except requests.exceptions.RequestException as e:
+            expected = (
+                'Error downloading {0}. Are you sure the URL '
+                'is correct and your internet connection is '
+                'functioning?'
+            ).format(stats_url)
+            self.assertIn(expected, str(e))
+
     def test_timeouts(self):
         with self.settings(DEBUG=True):
             with open(
@@ -216,7 +231,7 @@ class LoaderTestCase(TestCase):
             ), str(e))
 
     def test_request_blocking(self):
-        # FIXME: This will work 99% time but there is no garauntee with the
+        # FIXME: This will work 99% time but there is no guarantee with the
         # 4 second thing. Need a better way to detect if request was blocked on
         # not.
         wait_for = 3

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -26,5 +26,6 @@ deps =
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
+    requests: requests>= 2.21.0
 commands =
     coverage run --source=webpack_loader manage.py test {posargs}


### PR DESCRIPTION
This should allow us to load statics from a URL instead of a downloaded file in `wsgi.py`.

It's a fairly hacky fix but it should work fine. I even wrote a test?!?!?!?!?!?!

We'll likely put it in our `requirements.txt` file with a line like this:
```
...
-e git://github.com/uclapi/django-webpack-loader@master
...
```
Using `master` should be fine, as we'll be able to pull / cherry-pick any upstream changes we want right into our build. If upstream happens to support this behaviour natively then this fork will become redundant.

The developer has made it fairly clear in https://github.com/owais/django-webpack-loader/issues/143 that they do not want this behaviour to exist, but with `gunicorn` in place and with not wanting to version our assets (or we would have to push builds to Git too, due to the randomly named files) this looks like the best solution so far.