### PR TITLE
Fixed issue with loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ tests/webpack-stats-app2.json
 # PyCharm IDE
 .idea
 .vscode
+
+yarn.lock
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 # command to install dependencies
 before_install: "cd tests"
 install:
-  - pip install -r requirements-dev.txt
   - travis_retry pip install 'tox<3.0' coveralls
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 sudo: false
 # command to install dependencies
 before_install: "cd tests"
-install: travis_retry pip install 'tox<3.0' coveralls
+install:
+  - pip install -r requirements-dev.txt
+  - travis_retry pip install 'tox<3.0' coveralls
 # command to run tests
 script:
   - npm install

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -122,7 +122,7 @@ WEBPACK_LOADER = {
     'APP3': {
         'CACHE': False,
         'BUNDLE_DIR_NAME': 'bundles/',
-        'STATS_URL': "http://example.testing.url.internal/webpack-stats.json",
+        'STATS_URL': "http://example.testing.url.com/webpack-stats.json",
     }
 }
 

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -196,7 +196,7 @@ class LoaderTestCase(TestCase):
         stats_url = "http://example.testing.url.com/webpack-stats.json"
         try:
             get_loader(APP3).get_assets()
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             expected = (
                 'Error downloading {0}. Are you sure the URL '
                 'is correct and your internet connection is '

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -193,7 +193,7 @@ class LoaderTestCase(TestCase):
             self.assertIn(expected, str(e))
 
     def test_bad_stats_url(self):
-        stats_url = "http://example.testing.url.internal/webpack-stats.json"
+        stats_url = "http://example.testing.url.com/webpack-stats.json"
         try:
             get_loader(APP3).get_assets()
         except requests.exceptions.RequestException as e:

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -26,6 +26,6 @@ deps =
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
-    requests: requests>= 2.21.0
+    requests: requests>=2.21.0
 commands =
     coverage run --source=webpack_loader manage.py test {posargs}

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 envlist =
-    py26-django16
+    # py26-django16
     py27-django{16,17,18,19,110,111}
     py33-django{17,18}
     py34-django{17,18,19,110,111}
@@ -10,7 +10,7 @@ envlist =
 
 [testenv]
 basepython =
-    py26: python2.6
+    # py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
@@ -26,6 +26,6 @@ deps =
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
-    requests: requests>=2.21.0
+    requests
 commands =
     coverage run --source=webpack_loader manage.py test {posargs}

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -24,7 +24,20 @@ class WebpackLoader(object):
         self.config = load_config(self.name)
 
     def _load_assets(self):
-        if 'STATS_FILE' in self.config:
+        if 'STATS_URL' in self.config:
+            try:
+                r = requests.get(self.config['STATS_URL'])
+            except requests.exceptions.RequestException:
+                raise Exception(
+                    'Error downloading {0}. Are you sure the URL '
+                    'is correct and your internet connection is '
+                    'functioning?'.format(
+                        self.config['STATS_URL']
+                    )
+                )
+
+            return r.json()
+        elif 'STATS_FILE' in self.config:
             try:
                 with open(self.config['STATS_FILE'], encoding="utf-8") as f:
                     return json.load(f)
@@ -33,17 +46,6 @@ class WebpackLoader(object):
                     'Error reading {0}. Are you sure webpack has generated '
                     'the file and the path is correct?'.format(
                         self.config['STATS_FILE']))
-        elif 'STATS_URL' in self.config:
-            try:
-                r = requests.get(self.config['STATS_URL'])
-            except requests.exceptions.RequestException:
-                raise Exception(
-                    'Error downloading {0}. Are you sure the URL '
-                    'is correct and your internet connection is '
-                    'functioning?'
-                ).format(self.config['STATS_URL'])
-
-            return r.json()
 
     def get_assets(self):
         if self.config['CACHE']:


### PR DESCRIPTION
There is a default value for `STATS_FILE` of `webpack-stats.json` set in `webpack_loader/config.py#L13`, therefore `STATS_FILE' in self.config` is always `True`.

Therefore, we now check for `STATS_URL` before checking for `STATS_FILE` (which is more like an else statement really).

Also fixed typo: `.format` should be called on the string not on the exception obj.